### PR TITLE
fixed sed command in Dockerfile.upstream file

### DIFF
--- a/olm-testing/Dockerfile.upstream
+++ b/olm-testing/Dockerfile.upstream
@@ -3,9 +3,9 @@ FROM alpine as munger
 ARG new_image_name
 COPY upstream-manifests manifests
 RUN sed "s,quay.io/kubernetes-multicluster/federation-v2:v0.0.10,$new_image_name," -i manifests/federation/0.0.10/federation.v0.0.10.clusterserviceversion.yaml
-RUN sed "s,IfNotPresent,Always" -i manifests/federation/0.0.10/federation.v0.0.10.clusterserviceversion.yaml
+RUN sed "s,IfNotPresent,Always," -i manifests/federation/0.0.10/federation.v0.0.10.clusterserviceversion.yaml
 RUN sed "s,quay.io/kubernetes-multicluster/federation-v2:v0.0.10,$new_image_name," -i manifests/cluster-federation/0.0.10/cluster-federation.v0.0.10.clusterserviceversion.yaml
-RUN sed "s,IfNotPresent,Always" -i manifests/cluster-federation/0.0.10/cluster-federation.v0.0.10.clusterserviceversion.yaml
+RUN sed "s,IfNotPresent,Always," -i manifests/cluster-federation/0.0.10/cluster-federation.v0.0.10.clusterserviceversion.yaml
 
 FROM quay.io/openshift/origin-operator-registry:latest
 


### PR DESCRIPTION
The command
`IMAGE=quay.io/kubernetes-multicluster/federation-v2:v0.0.10 ./scripts/push-operator-registry.sh sohankunkerkar` was failing due to the following error:
```
sed: unmatched ','
The command '/bin/sh -c sed "s,IfNotPresent,Always" -i manifests/federation/0.0.10/federation.v0.0.10.clusterserviceversion.yaml' returned a non-zero code: 1
```
I'm filing this PR to fix this issue.